### PR TITLE
Return process exit code

### DIFF
--- a/run-hidden.cpp
+++ b/run-hidden.cpp
@@ -79,7 +79,12 @@ int APIENTRY wWinMain(
     // Wait until child process exits.
     WaitForSingleObject(pi.hProcess, INFINITE);
 
+    DWORD exit_code = 1;
+    GetExitCodeProcess(pi.hProcess, &exit_code);
+    
     // Close process and thread handles. 
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
+
+    return exit_code;
 }


### PR DESCRIPTION
If run-hidden is executed by a third application e.g. the task scheduler, the exit code of the powershell script is now returned by run-hidden